### PR TITLE
Python3 get_uri secret fix #1

### DIFF
--- a/spookyotp/otp.py
+++ b/spookyotp/otp.py
@@ -98,7 +98,7 @@ class OTPBase(object):
         Complies with the google-authenticator KeyUriFormat
         """
         encoded_otp_type = quote(cls._otp_type)
-        encoded_secret = base64.b32encode(secret)
+        encoded_secret = base64.b32encode(secret).decode()
         encoded_issuer = quote(issuer)
         encoded_account = quote(account)
         encoded_algorithm = quote(algorithm)


### PR DESCRIPTION
Fix Python 3 issue where secret=b'E3NLBLC7VGSO6M3B' not
secret=E3NLBLC7VGSO6M3B
